### PR TITLE
build!: update MSRV 1.53.0

### DIFF
--- a/contrib/db_pools/lib/Cargo.toml
+++ b/contrib/db_pools/lib/Cargo.toml
@@ -9,6 +9,11 @@ keywords = ["rocket", "framework", "database", "pools"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
 
+[package.metadata]
+# minimum supported rust version 1.53.0 because of
+# error[E0391]: cycle detected when computing the supertraits of `database::Database`
+msrv = 1.53.0
+
 [package.metadata.docs.rs]
 all-features = true
 

--- a/contrib/db_pools/lib/Cargo.toml
+++ b/contrib/db_pools/lib/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [package.metadata]
 # minimum supported rust version 1.53.0 because of
 # error[E0391]: cycle detected when computing the supertraits of `database::Database`
-msrv = 1.53.0
+msrv = "1.53.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/core/codegen/Cargo.toml
+++ b/core/codegen/Cargo.toml
@@ -11,6 +11,10 @@ keywords = ["rocket", "web", "framework", "code", "generation"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
 
+[package.metadata]
+# minimum supported rust version 1.51.0 because of cargo resolver in dependency crate time
+msrv = "1.51.0"
+
 [lib]
 proc-macro = true
 

--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -14,6 +14,10 @@ license = "MIT OR Apache-2.0"
 categories = ["web-programming"]
 edition = "2018"
 
+[package.metadata]
+# minimum supported rust version 1.51.0 because of cargo resolver in dependency crate time
+msrv = "1.51.0"
+
 [features]
 default = []
 tls = ["rustls", "tokio-rustls"]

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -16,8 +16,10 @@ categories = ["web-programming::http-server"]
 edition = "2018"
 
 [package.metadata]
-# minimum supported rust version 1.51.0 because of dependencies multer -> spin
-msrv = "1.51.0"
+# minimum supported rust version 1.53.0 because of 
+# TlsConfig::with_ciphers() based on crate indexmap needs IntoIterator impls
+# on arrays of any length from 1.53.0
+msrv = "1.53.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -15,6 +15,10 @@ build = "build.rs"
 categories = ["web-programming::http-server"]
 edition = "2018"
 
+[package.metadata]
+# minimum supported rust version 1.51.0 because of dependencies multer -> spin
+msrv = "1.51.0"
+
 [package.metadata.docs.rs]
 all-features = true
 

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["web-programming::http-server"]
 edition = "2018"
 
 [package.metadata]
-# minimum supported rust version 1.53.0 because of 
+# minimum supported rust version 1.53.0 because of
 # TlsConfig::with_ciphers() based on crate indexmap needs IntoIterator impls
 # on arrays of any length from 1.53.0
 msrv = "1.53.0"

--- a/core/lib/build.rs
+++ b/core/lib/build.rs
@@ -3,7 +3,7 @@
 use yansi::{Paint, Color::{Red, Yellow}};
 
 fn main() {
-    const MIN_VERSION: &str = "1.46.0";
+    const MIN_VERSION: &str = "1.51.0";
 
     if let Some(version) = version_check::Version::read() {
         if !version.at_least(MIN_VERSION) {

--- a/core/lib/build.rs
+++ b/core/lib/build.rs
@@ -3,7 +3,7 @@
 use yansi::{Paint, Color::{Red, Yellow}};
 
 fn main() {
-    const MIN_VERSION: &str = "1.51.0";
+    const MIN_VERSION: &str = "1.53.0";
 
     if let Some(version) = version_check::Version::read() {
         if !version.at_least(MIN_VERSION) {


### PR DESCRIPTION
Set the minimum required rustc version to 1.53.0.  
Below it doesn't make sense, because not all parts and tests of Rocket would compile.

There follows another PR to patch some little things to get all tests run also with MSRV and nightly.